### PR TITLE
Fix tests

### DIFF
--- a/spec/type-spec.js
+++ b/spec/type-spec.js
@@ -1,22 +1,19 @@
 describe("[[R7Storage]]", function() {
   describe("[Setting technology type]", function() {
-    var store;
-    beforeEach(function(){
-      store = R7Storage;
-    });
+    var store = R7Storage;
 
     it("must the type() be empty", function() {
       expect(store.type).toBe("");
     });
 
     it("Must the type() be cookies", function() {
-      R7Storage.use("cookies");
-      expect(R7Storage.type).toBe("cookies");
+      store.use("cookies");
+      expect(store.type).toBe("cookies");
     });
 
     it("must the type() be localStorage", function() {
-      R7Storage.use("localStorage");
-      expect(R7Storage.type).toBe("localStorage");
+      store.use("localStorage");
+      expect(store.type).toBe("localStorage");
     });
   });
 });


### PR DESCRIPTION
This should fix the #2 issue

Fix typo error `localstorage` should be `localStorage`. 

Removing the unnecessary `beforeEach` since we're dealing with a simple global Object, so the `beforeEach` is not cleaning the `R7Storage` state, it's just reassigning the `var store` every time.
